### PR TITLE
Use the grott HA extension instead of bundunling the file

### DIFF
--- a/grott/.README.j2
+++ b/grott/.README.j2
@@ -1,8 +1,8 @@
 # Grott - Home Assistant native MQTT integration
 
-![Release][release-shield]][release] ![Project Stage][project-stage-shield] ![Project Maintenance][maintenance-shield]
+[![Release][release-shield]][release] ![Project Stage][project-stage-shield] ![Project Maintenance][maintenance-shield]
 
-
+[!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/egguy)
 
 This addon allow you to run a local version of grott with the HA plugin
 and auto discovery enabled.
@@ -10,12 +10,11 @@ and auto discovery enabled.
 The data is fowarded to the growatt's server.
 The grott server decode them and send them to your HA instance.
 
-This addon is based on the 2.7.8
-[grott](https://github.com/johanmeijer/grott) code
-and current grott_ha extension.
+This addon is based on the 2.7.8 [grott](https://github.com/johanmeijer/grott) code and current grott_ha extension.
 
 {% if channel == "edge" %}
-## WARNING! THIS IS AN EDGE VERSION!
+
+## WARNING! THIS IS AN EDGE VERSION
 
 This Home Assistant Add-ons repository contains edge builds of add-ons.
 Edge builds add-ons are based upon the latest development version.
@@ -36,7 +35,8 @@ If you are more interested in stable releases of our add-ons:
 
 {% endif %}
 {% if channel == "beta" %}
-## WARNING! THIS IS A BETA VERSION!
+
+## WARNING! THIS IS A BETA VERSION
 
 This Home Assistant Add-ons repository contains beta releases of add-ons.
 
@@ -55,5 +55,6 @@ If you are more interested in stable releases of our add-ons:
 {% endif %}
 
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg
-[release-shield]: https://img.shields.io/badge/version-{{ version }}-blue.svg
+[release-shield]: <https://img.shields.io/badge/version-{{> version }}-blue.svg
 [release]: {{ repo }}/tree/{{ version }}
+[docs]: https://github.com/egguy/addon-grott/blob/main/grott/DOCS.md

--- a/grott/Dockerfile
+++ b/grott/Dockerfile
@@ -18,8 +18,6 @@ RUN chmod a+x /app/script.sh
 
 WORKDIR /app
 RUN curl -Lk 'https://github.com/johanmeijer/grott/archive/refs/heads/master.zip' --output files.zip && unzip -o files.zip && rm files.zip && mv grott-*/*.py ./
-# Move the addon
-RUN curl -L 'https://raw.githubusercontent.com/egguy/grott/feature/ha-extension/examples/Home%20Assistent/grott_ha.py' -o grott_ha.py
 
 COPY requirements.txt requirements.txt
 #Install required python packages
@@ -38,17 +36,17 @@ ARG BUILD_VERSION
 
 # Labels
 LABEL \
-    io.hass.name="${BUILD_NAME}" \
-    io.hass.description="${BUILD_DESCRIPTION}" \
-    io.hass.arch="${BUILD_ARCH}" \
-    io.hass.type="addon" \
-    io.hass.version=${BUILD_VERSION} \
-    maintainer="egguy <etienne.guilluy@gmail.com>" \
-    org.opencontainers.image.title="${BUILD_NAME}" \
-    org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
-    org.opencontainers.image.authors="egguy <etienne.guilluy@gmail.com>" \
-    org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
-    org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
-    org.opencontainers.image.created=${BUILD_DATE} \
-    org.opencontainers.image.revision=${BUILD_REF} \
-    org.opencontainers.image.version=${BUILD_VERSION}
+        io.hass.name="${BUILD_NAME}" \
+        io.hass.description="${BUILD_DESCRIPTION}" \
+        io.hass.arch="${BUILD_ARCH}" \
+        io.hass.type="addon" \
+        io.hass.version=${BUILD_VERSION} \
+        maintainer="egguy <etienne.guilluy@gmail.com>" \
+        org.opencontainers.image.title="${BUILD_NAME}" \
+        org.opencontainers.image.description="${BUILD_DESCRIPTION}" \
+        org.opencontainers.image.authors="egguy <etienne.guilluy@gmail.com>" \
+        org.opencontainers.image.source="https://github.com/${BUILD_REPOSITORY}" \
+        org.opencontainers.image.documentation="https://github.com/${BUILD_REPOSITORY}/blob/main/README.md" \
+        org.opencontainers.image.created=${BUILD_DATE} \
+        org.opencontainers.image.revision=${BUILD_REF} \
+        org.opencontainers.image.version=${BUILD_VERSION}

--- a/grott/requirements.txt
+++ b/grott/requirements.txt
@@ -1,3 +1,4 @@
 paho-mqtt==1.6.1
 requests==2.31.0
 influxdb==5.3.1
+grott-ha-plugin==0.9.0

--- a/grott/script.sh
+++ b/grott/script.sh
@@ -225,7 +225,7 @@ fi
 if bashio::config.true 'ha_plugin'; then
     # pre configure the extension to use the integrated mosquitto broker
     gextension="True"
-    gextname="grott_ha"
+    gextname="grottext.ha"
     # shellcheck disable=SC2089
     gextvar="{\"ha_mqtt_host\": \"$GROTT_CONFIG_MQTT_HOST\", \"ha_mqtt_port\": \"$GROTT_CONFIG_MQTT_PORT\", \"ha_mqtt_user\": \"$GROTT_CONFIG_MQTT_USER\", \"ha_mqtt_password\": \"$GROTT_CONFIG_MQTT_PASSWORD\", \"ha_mqtt_retain\": $MQTT_RETAIN}"
     export gextension


### PR DESCRIPTION
# Proposed Changes

> Use the created grott-ha-extension in the requirements file instead of copying. This will faciliate update and maintenance.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
