### PR TITLE
Addon configuration migration

### DIFF
--- a/grott/DOCS.md
+++ b/grott/DOCS.md
@@ -121,7 +121,7 @@ It is recommended to deactivate the **Home Assistant plugin** in the configurati
 
 ## Configuration of grott
 
-The add-on creates a folder in home assistant. You can find it in the `/config/grott` folder of your home assistant instance.
+The add-on creates a folder in home assistant. You can find it in the `/addon_configs/grott/` folder of your home assistant instance.
 
 You can create/modify the `grott.ini` using the file editor add-on or VS Code add-on. This allows you to add pvoutput support or to add a custom JSON layout.
 

--- a/grott/config.yaml
+++ b/grott/config.yaml
@@ -14,7 +14,7 @@ services:
   - mqtt:need
 init: false
 map:
-  - config:rw
+  - addon_config:rw
   - homeassistant_config:rw
 ports:
   5279/tcp: 5279

--- a/grott/config.yaml
+++ b/grott/config.yaml
@@ -15,6 +15,7 @@ services:
 init: false
 map:
   - config:rw
+  - homeassistant_config:rw
 ports:
   5279/tcp: 5279
 ports_description:

--- a/grott/script.sh
+++ b/grott/script.sh
@@ -9,6 +9,15 @@ bashio::log.info "Preparing to start..."
 # - https://github.com/zigbee2mqtt/hassio-zigbee2mqtt/issues/387
 bashio::config.require 'data_path'
 
+# Migrate add-on data from the Home Assistant config folder,
+# to the add-on configuration folder.
+if ! bashio::fs.directory_exists '/config/grott/' \
+    && bashio::fs.file_exists '/homeassistant/grott/grott.ini'; then
+    bashio::log.info "Mirgrating data from Home Assistant to add-on config folder"
+    mkdir -p /config/grott || bashio::exit.nok "Failed to create Grott configuration folder"
+    cp -rf /homeassistant/grott/* /config/grott/ || bashio::exit.nok "Failed to migrate Grott configuration"
+fi
+
 DATA_PATH=$(bashio::config 'data_path')
 if ! bashio::fs.file_exists "$DATA_PATH/grott.ini"; then
     mkdir -p "$DATA_PATH" || bashio::exit.nok "Could not create $DATA_PATH"


### PR DESCRIPTION
# Proposed Changes

Add a migration for the way to store HA add-on's configuration: https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
