### PR TITLE
feat: Use the python image for the addon

### DIFF
--- a/grott/Dockerfile
+++ b/grott/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -Lk "https://github.com/johanmeijer/grott/archive/$GIT_REF.zip" --outpu
 
 COPY requirements.txt requirements.txt
 #Install required python packages
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 CMD [ "./script.sh" ]
 

--- a/grott/Dockerfile
+++ b/grott/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:15.0.6
+ARG BUILD_FROM=ghcr.io/hassio-addons/base-python:13.1.2
 # hadolint ignore=DL3006
 FROM $BUILD_FROM
 
@@ -7,10 +7,6 @@ ENV LANG C.UTF-8
 
 # Install python/pip
 ENV PYTHONUNBUFFERED=1
-RUN apk add --update --no-cache \
-        python3=3.11.6-r1 \
-        bind-tools=9.18.19-r1 \
-        py3-pip=23.3.1-r0
 
 # Copy data for add-on
 COPY script.sh /app/script.sh

--- a/grott/build.yaml
+++ b/grott/build.yaml
@@ -1,9 +1,9 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:15.0.6
-  amd64: ghcr.io/hassio-addons/base/amd64:15.0.6
-  armhf: ghcr.io/hassio-addons/base/armhf:15.0.6
-  armv7: ghcr.io/hassio-addons/base/armv7:15.0.6
-  i386: ghcr.io/hassio-addons/base/i386:15.0.6
+  aarch64: ghcr.io/hassio-addons/base-python/aarch64:13.1.2
+  amd64: ghcr.io/hassio-addons/base-python/amd64:13.1.2
+  armhf: ghcr.io/hassio-addons/base-python/armhf:13.1.2
+  armv7: ghcr.io/hassio-addons/base-python/armv7:13.1.2
+  i386: ghcr.io/hassio-addons/base-python/i386:13.1.2
 codenotary:
   base_image: codenotary@frenck.dev


### PR DESCRIPTION
# Proposed Changes

> Use the python base image from HA.
> This will reduce the maintenance as there is less packages to install

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
